### PR TITLE
Fix Undergarments Toggle

### DIFF
--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -48,6 +48,7 @@
 			var/new_undies = input(H, "Select your underwear", "Changing") as null|anything in GLOB.underwear_list
 			if(H.underwear)
 				H.underwear = new_undies
+				H.hidden_underwear = 0
 				H.saved_underwear = new_undies
 				var/datum/sprite_accessory/underwear/bottom/B = GLOB.underwear_list[new_undies]
 				dye_undie = B?.has_color
@@ -55,6 +56,7 @@
 			var/new_undershirt = input(H, "Select your undershirt", "Changing") as null|anything in GLOB.undershirt_list
 			if(new_undershirt)
 				H.undershirt = new_undershirt
+				H.hidden_undershirt = 0
 				H.saved_undershirt = new_undershirt
 				var/datum/sprite_accessory/underwear/top/T = GLOB.undershirt_list[new_undershirt]
 				dye_shirt = T?.has_color
@@ -62,6 +64,7 @@
 			var/new_socks = input(H, "Select your socks", "Changing") as null|anything in GLOB.socks_list
 			if(new_socks)
 				H.socks = new_socks
+				H.hidden_socks = 0
 				H.saved_socks = new_socks
 				var/datum/sprite_accessory/underwear/socks/S = GLOB.socks_list[new_socks]
 				dye_socks = S?.has_color

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -513,7 +513,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			if(H.hidden_underwear)
 				H.underwear = "Nude"
 			else
-				H.saved_underwear = H.underwear
+				H.underwear = H.saved_underwear
 				var/datum/sprite_accessory/underwear/bottom/B = GLOB.underwear_list[H.underwear]
 				if(B)
 					var/mutable_appearance/MA = mutable_appearance(B.icon, B.icon_state, -BODY_LAYER)
@@ -525,7 +525,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			if(H.hidden_undershirt)
 				H.undershirt = "Nude"
 			else
-				H.saved_undershirt = H.undershirt
+				H.undershirt = H.saved_undershirt
 				var/datum/sprite_accessory/underwear/top/T = GLOB.undershirt_list[H.undershirt]
 				if(T)
 					var/mutable_appearance/MA
@@ -541,7 +541,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			if(H.hidden_socks)
 				H.socks = "Nude"
 			else
-				H.saved_socks = H.socks
+				H.socks = H.saved_socks
 				var/datum/sprite_accessory/underwear/socks/S = GLOB.socks_list[H.socks]
 				if(S)
 					var/digilegs = (DIGITIGRADE in species_traits) ? "_d" : ""


### PR DESCRIPTION
## About The Pull Request
Currently, toggling undergarments makes them disappear. This PR fixes that.
Undergarments will also be toggled visible if changed using a Dresser.

## Why It's Good For The Game
Makes toggling undergarments work as intended and provides better feedback if changed while toggled off.

## Changelog
:cl:
fix: Toggle Undergarments no longer makes them disappear.
/:cl:
